### PR TITLE
remove fix value

### DIFF
--- a/validator/main.py
+++ b/validator/main.py
@@ -52,7 +52,6 @@ class ReadingTime(Validator):
             return FailResult(
                 error_message=f"String should be readable "
                 f"within {self._max_time} minutes.",
-                fix_value=value,
             )
 
         return PassResult()


### PR DESCRIPTION
The doc string says that this validator doesn't offer a programmatic fix and the fix value that was being assigned was just the original value that failed.  Removing this for now.